### PR TITLE
Plot row CSS formatting and responsive widths

### DIFF
--- a/js/components/BarComp.js
+++ b/js/components/BarComp.js
@@ -2,21 +2,29 @@ import React from "react"
 import ReactDOM from "react-dom"
 import rd3 from 'react-d3'
 
-export default class BarComp extends React.Component {
+import ResponsiveComponent from './ResponsiveComponent'
 
-	constructor(props) {
-		super(props)
-	}
+export default class BarComp extends ResponsiveComponent {
 
-	render() {
-	var BarChart = rd3.BarChart;
-	return (<div>
-		      <BarChart
-			      data={this.props.data}
-			      title={this.props.title}
-			      xAxisLabel={this.props.xAxisLabel}
-			      yAxisLabel={this.props.yAxisLabel}
-			      />
-	       </div>)
-	}
+    constructor(props) {
+        super(props)
+    }
+
+    render() {
+        var BarChart = rd3.BarChart;
+
+        let {parentWidth} = this.state;
+        let width = parentWidth - 120;
+
+        return (<div class='plots'>
+                <BarChart
+                    width={width}
+                    height={225}
+                    data={this.props.data}
+                    title={this.props.title}
+                    xAxisLabel={this.props.xAxisLabel}
+                    yAxisLabel={this.props.yAxisLabel}
+                    />
+            </div>)
+    }
 }

--- a/js/components/DataView.js
+++ b/js/components/DataView.js
@@ -8,37 +8,39 @@ import DataTable from './DataTable'
 
 export default class DataView extends React.Component {
 
-	constructor(props) {
-		super(props)
-	}
+    constructor(props) {
+        super(props)
+    }
 
-	render() {
-		var plotArea = (<div></div>)
-		if (this.props.oneLoadComplete) {
-			if (this.props.listings.length == 0) {
-				plotArea = <PlotsNone />
-			}
-			else {
-				plotArea = (
-							<Plots listings={this.props.listings} />
-				)
-			}
-		}
-		return (
-				<div className="container">
-					<div id="mapAndPlotRow" className="row clearfix">
-						<div className="col-md-5 float-xs-left">
-							<OpenHouseMap listings={this.props.listings} position={this.props.position} zoom={this.props.zoom} setPositionAndZoom={this.props.setPositionAndZoom} />    				
-						</div>		
+    render() {
+        var plotArea = (<div></div>)
+        if (this.props.oneLoadComplete) {
+            if (this.props.listings.length == 0) {
+                plotArea = <PlotsNone />
+            }
+            else {
+                plotArea = (
+                            <Plots listings={this.props.listings} />
+                )
+            }
+        }
+        return (
+                <div className="container">
+                    <div id="mapAndPlotRow" className="row">
+                        <div className="col-lg-6">
+                            <OpenHouseMap listings={this.props.listings} position={this.props.position} zoom={this.props.zoom} setPositionAndZoom={this.props.setPositionAndZoom} />
+                        </div>
 
-						<div className="col-md-5 float-xs-right">
-							{plotArea}
-						</div>
-					</div>
-					<div className="row">
-						<DataTable listings={this.props.listings} />
-					</div>
-				</div>
-		)
-	}
+                        <div className="col-lg-6">
+                            {plotArea}
+                        </div>
+                    </div>
+                    <div className="row">
+                        <div className="col-sm-12">
+                            <DataTable listings={this.props.listings} />
+                        </div>
+                    </div>
+                </div>
+        )
+    }
 }

--- a/js/components/OpenHouseMap.js
+++ b/js/components/OpenHouseMap.js
@@ -32,6 +32,7 @@ export default class OpenHouseMap extends React.Component {
     const position = [this.props.position.latitude, this.props.position.longitude]
     return (
       <Map
+        style={{flex: 1}}
         ref={(map) => { this.themap = map; }}
         class="the-map"
         onMoveend={this.handleMoveend}
@@ -55,7 +56,7 @@ export default class OpenHouseMap extends React.Component {
                     </span>
                   </Popup>
                 </Marker>
-              )              
+              )
             }
           })}
       </Map>

--- a/js/components/ResponsiveComponent.js
+++ b/js/components/ResponsiveComponent.js
@@ -1,0 +1,36 @@
+import React from "react"
+import ReactDOM from "react-dom"
+import rd3 from 'react-d3'
+
+export default class ResponsiveComponent extends React.Component {
+
+    constructor(props) {
+        super(props)
+        this.state = {parentWidth: 0};
+    }
+
+    handleResize(e) {
+        let elem = ReactDOM.findDOMNode(this);
+        let width = elem.parentNode.offsetWidth;
+        if (this.state.parentWidth != width) {
+            this.setState({
+                parentWidth: width
+            });
+        }
+    }
+
+    componentDidMount() {
+        window.addEventListener('resize', ::this.handleResize);
+        setTimeout(::this.handleResize, 10);
+    }
+
+    componentWillReceiveProps() {
+        this.handleResize();
+    }
+
+    componentWillUnmount() {
+        window.removeEventListener('resize', ::this.handleResize);
+    }
+
+    render() {}
+}

--- a/js/components/ScatterComp.js
+++ b/js/components/ScatterComp.js
@@ -2,22 +2,30 @@ import React from "react"
 import ReactDOM from "react-dom"
 import rd3 from 'react-d3'
 
-export default class ScatterComp extends React.Component {
+import ResponsiveComponent from './ResponsiveComponent'
 
-	constructor(props) {
-		super(props)
-	}
+export default class ScatterComp extends ResponsiveComponent {
 
-	render() {
-	var ScatterChart = rd3.ScatterChart;
-	return (<div>
-				<ScatterChart
-				data={this.props.data}
-				title={this.props.title}
-				xAxisLabel={this.props.xAxisLabel}
-				yAxisLabel={this.props.yAxisLabel}
-				domain={this.props.domain}
-				/>
-	       </div>)
-	}
+    constructor(props) {
+        super(props)
+    }
+
+    render() {
+    var ScatterChart = rd3.ScatterChart;
+
+    let {parentWidth} = this.state;
+    let width = parentWidth - 120;
+
+    return (<div class='plots'>
+                <ScatterChart
+                width={width}
+                height={225}
+                data={this.props.data}
+                title={this.props.title}
+                xAxisLabel={this.props.xAxisLabel}
+                yAxisLabel={this.props.yAxisLabel}
+                domain={this.props.domain}
+                />
+            </div>)
+    }
 }

--- a/style.css
+++ b/style.css
@@ -87,9 +87,6 @@ body {
   float:left;
 }
 /* Alex K Changes */
-.row {
-  margin-bottom: 20px;
-}
 
 #logo-img {
   margin-left: 5px;
@@ -116,14 +113,11 @@ body {
 }
 
 #mapAndPlotRow {
-  padding-right: 5em;*/
-}
-
-#rowOneLeft {
+  margin-bottom: 20px;
 }
 
 #filters {
-  padding: 1.5rem;
+  margin-top: 1.5rem;
 }
 
 
@@ -142,20 +136,6 @@ body {
 #btnCopy {
     width: 25px;
     height: 15px;
-}
-
-#rowOneLeft {
-}
-
-.col-sm-6 {
-  overflow: hidden;
-  height: 90px;
-}
-
-.col-md-6 {
-  margin-left: 400px;
-  min-width: 300px;
-  width: 50%;
 }
 
 #rowOne {
@@ -227,13 +207,16 @@ body {
 
 .the-map {
   height: 300px;
-  width: 400px;
 }
 
 /*********************************************************
   PLOTS
 **********************************************************/
 
+
+.plots {
+  height: 300px;
+}
 
 .rd3-basic-chart {
   margin-left: 55px;
@@ -242,13 +225,8 @@ body {
 
 .plots-empty {
   background-color: #eee;
-  width: 400px;
   height: 300px;
   padding: 10px;
-}
-
-.Plots {
-  width: 500px
 }
 
 .rd3-chart {
@@ -282,20 +260,20 @@ body {
   SLIDER
 **********************************************************/
 
-.slider {
+#filters .slider {
   margin-bottom: 5px;
   margin-left: 10px;
   width: 200px;
   height: 40px;
 }
-.slider_vals {
+#filters .slider_vals {
   height: 20px;
   line-height: 25px;
 }
-.slider_outer {
+#filters .slider_outer {
   height: 40px;
 }
-.slider_label {
+#filters .slider_label {
   font-size: 8pt;
 }
 


### PR DESCRIPTION
This change:
1) cleans up the spacing of the elements in the map and plot row
2) resizes the width of the map and plots based on the window size

It also looks like my editor converted some tabs to spaces - let me know if you'd like me to revert those back to tabs.

I tried joining the slack channel like the contributing instructions recommend, but it looks like it is restricted to only certain domains (or I just don't know how to use slack...).

